### PR TITLE
Redirect stdout and stderr to /dev/null

### DIFF
--- a/depends/check-gmp.sh
+++ b/depends/check-gmp.sh
@@ -2,12 +2,12 @@
 # check-gmp.sh by uyjulian
 
 ## Check for the gmp library.
-ls /usr/include/gmp.h 1> /dev/null || \
-ls /usr/local/include/gmp.h 1> /dev/null || \
-ls /opt/include/gmp.h 1> /dev/null || \
-ls /opt/local/include/gmp.h 1> /dev/null || \
-ls /usr/include/x86_64-linux-gnu/gmp.h 1> /dev/null || \
-ls /usr/local/include/x86_64-linux-gnu/gmp.h 1> /dev/null || \
-ls /usr/include/i386-linux-gnu/gmp.h 1> /dev/null || \
-ls /usr/local/include/i386-linux-gnu/gmp.h 1> /dev/null || \
+ls /usr/include/gmp.h > /dev/null 2>&1 || \
+ls /usr/local/include/gmp.h > /dev/null 2>&1 || \
+ls /opt/include/gmp.h > /dev/null 2>&1 || \
+ls /opt/local/include/gmp.h > /dev/null 2>&1 || \
+ls /usr/include/x86_64-linux-gnu/gmp.h > /dev/null 2>&1 || \
+ls /usr/local/include/x86_64-linux-gnu/gmp.h > /dev/null 2>&1 || \
+ls /usr/include/i386-linux-gnu/gmp.h > /dev/null 2>&1 || \
+ls /usr/local/include/i386-linux-gnu/gmp.h > /dev/null 2>&1 || \
 { echo "ERROR: Install gmp before continuing."; exit 1; }

--- a/depends/check-mpc.sh
+++ b/depends/check-mpc.sh
@@ -2,8 +2,8 @@
 # check-mpc.sh by uyjulian
 
 ## Check for the mpc library.
-ls /usr/include/mpc.h 1> /dev/null || \
-ls /usr/local/include/mpc.h 1> /dev/null || \
-ls /opt/include/mpc.h 1> /dev/null || \
-ls /opt/local/include/mpc.h 1> /dev/null || \
+ls /usr/include/mpc.h > /dev/null 2>&1 || \
+ls /usr/local/include/mpc.h > /dev/null 2>&1 || \
+ls /opt/include/mpc.h > /dev/null 2>&1 || \
+ls /opt/local/include/mpc.h > /dev/null 2>&1 || \
 { echo "ERROR: Install mpc before continuing."; exit 1; }

--- a/depends/check-mpfr.sh
+++ b/depends/check-mpfr.sh
@@ -2,8 +2,8 @@
 # check-mpfr.sh by uyjulian
 
 ## Check for the mpfr library.
-ls /usr/include/mpfr.h 1> /dev/null || \
-ls /usr/local/include/mpfr.h 1> /dev/null || \
-ls /opt/include/mpfr.h 1> /dev/null || \
-ls /opt/local/include/mpfr.h 1> /dev/null || \
+ls /usr/include/mpfr.h > /dev/null 2>&1 || \
+ls /usr/local/include/mpfr.h > /dev/null 2>&1 || \
+ls /opt/include/mpfr.h > /dev/null 2>&1 || \
+ls /opt/local/include/mpfr.h > /dev/null 2>&1 || \
 { echo "ERROR: Install mpfr before continuing."; exit 1; }


### PR DESCRIPTION
Modified the stdout redirects in the gmp, mpc, and mpfr scripts
to also redirect stderr to /dev/null. This is only necessary for
multiple checks before handling a 'file not found' exception.